### PR TITLE
dump_json: fix when longrepr has no toterminal

### DIFF
--- a/pytest_litf.py
+++ b/pytest_litf.py
@@ -141,11 +141,14 @@ class LitfTerminalReporter(TerminalReporter):
         errors = {}
         for report in reports:
             if report.outcome == "failed" and report.longrepr:
-                # Compute human repre
-                tw = py.io.TerminalWriter(stringio=True)
-                tw.hasmarkup = False
-                report.longrepr.toterminal(tw)
-                exc = tw.stringio.getvalue()
+                if hasattr(report.longrepr, 'toterminal'):
+                    # Compute human repre
+                    tw = py.io.TerminalWriter(stringio=True)
+                    tw.hasmarkup = False
+                    report.longrepr.toterminal(tw)
+                    exc = tw.stringio.getvalue()
+                else:
+                    exc = str(report.longrepr)
                 humanrepr = exc.strip()
 
                 errors[report.when] = {"humanrepr": humanrepr}


### PR DESCRIPTION
Some plugins generate a longrepr which is a string, and does not have a
'toterminal' method. I had the case with pytest-pycodestyle 1.4.0 and
pycodestyle 2.5.0.

(Balto was failing without any visual feedback)